### PR TITLE
Dynamic Image Support, Text Improvements, Zoom Level Setting

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "6d0071977ed1f2380c739715f82ac650f99b0824",
-        "version" : "6.4.0"
+        "revision" : "039ef525064a685c291db5118f6b5f6e8b090bb0",
+        "version" : "6.5.2"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stadiamaps/maplibre-swift-macros.git",
       "state" : {
-        "revision" : "d52adbcbfaf96bd0723a156bd838826916ff7a69",
-        "version" : "0.0.3"
+        "revision" : "236215c13bff962009e0f0257d6d8349be33442f",
+        "version" : "0.0.4"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "3b79620f2b916941035b5544bbca321fa7b33ed4",
-        "version" : "0.0.3"
+        "branch" : "main",
+        "revision" : "ccec0efd3e4a48b85b5407f788916de265c986dc"
       }
     },
     {
@@ -32,14 +32,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
-        "version" : "1.16.0"
+        "revision" : "c097f955b4e724690f0fc8ffb7a6d4b881c9c4e3",
+        "version" : "1.17.2"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.4.0"),
         .package(url: "https://github.com/stadiamaps/maplibre-swift-macros.git", from: "0.0.3"),
         // Testing
-        .package(url: "https://github.com/Kolos65/Mockable.git", exact: "0.0.3"),
+        .package(url: "https://github.com/Kolos65/Mockable.git", branch: "main"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.15.3"),
     ],
     targets: [

--- a/Sources/MapLibreSwiftDSL/Style Layers/Circle.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Circle.swift
@@ -9,6 +9,7 @@ import MapLibreSwiftMacros
 @MLNStyleProperty<UIColor>("strokeColor", supportsInterpolation: false)
 public struct CircleStyleLayer: SourceBoundVectorStyleLayerDefinition {
     public let identifier: String
+    public let sourceLayerIdentifier: String?
     public var insertionPosition: LayerInsertionPosition = .aboveOthers
     public var isVisible: Bool = true
     public var maximumZoomLevel: Float? = nil
@@ -20,11 +21,13 @@ public struct CircleStyleLayer: SourceBoundVectorStyleLayerDefinition {
     public init(identifier: String, source: Source) {
         self.identifier = identifier
         self.source = .source(source)
+        self.sourceLayerIdentifier = nil
     }
 
-    public init(identifier: String, source: MLNSource) {
+    public init(identifier: String, source: MLNSource, sourceLayerIdentifier: String? = nil) {
         self.identifier = identifier
         self.source = .mglSource(source)
+        self.sourceLayerIdentifier = sourceLayerIdentifier
     }
 
     public func makeStyleLayer(style: MLNStyle) -> StyleLayer {
@@ -69,6 +72,7 @@ private struct CircleStyleLayerInternal: StyleLayer {
     public func makeMLNStyleLayer() -> MLNStyleLayer {
         let result = MLNCircleStyleLayer(identifier: identifier, source: mglSource)
 
+        result.sourceLayerIdentifier = definition.sourceLayerIdentifier
         result.circleRadius = definition.radius
         result.circleColor = definition.color
 

--- a/Sources/MapLibreSwiftDSL/Style Layers/Style Layer.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Style Layer.swift
@@ -161,3 +161,13 @@ public extension StyleLayer {
         modified(self) { $0.insertionPosition = .belowOthers }
     }
 }
+
+public extension StyleLayerDefinition {
+    func minimumZoomLevel(_ value: Float) -> Self {
+        modified(self) { $0.minimumZoomLevel = value }
+    }
+    
+    func maximumZoomLevel(_ value: Float) -> Self {
+        modified(self) { $0.maximumZoomLevel = value }
+    }
+}

--- a/Sources/MapLibreSwiftDSL/Style Layers/Symbol.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Symbol.swift
@@ -160,6 +160,14 @@ private struct SymbolStyleLayerInternal: StyleLayer {
         result.textHaloBlur = definition.textHaloBlur
         
         result.predicate = definition.predicate
+        
+        if let minimumZoomLevel = definition.minimumZoomLevel {
+            result.minimumZoomLevel = minimumZoomLevel
+        }
+        
+        if let maximumZoomLevel = definition.maximumZoomLevel {
+            result.maximumZoomLevel = maximumZoomLevel
+        }
 
         return result
     }

--- a/Sources/MapLibreSwiftDSL/Style Layers/Symbol.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Symbol.swift
@@ -5,13 +5,23 @@ import MapLibreSwiftMacros
 
 @MLNStyleProperty<Double>("iconRotation", supportsInterpolation: true)
 @MLNStyleProperty<UIColor>("iconColor", supportsInterpolation: true)
+@MLNStyleProperty<Bool>("iconAllowsOverlap", supportsInterpolation: false)
+
 @MLNStyleProperty<UIColor>("textColor", supportsInterpolation: true)
 @MLNStyleProperty<Double>("textFontSize", supportsInterpolation: true)
 @MLNStyleProperty<String>("text", supportsInterpolation: false)
-@MLNStyleProperty<Bool>("iconAllowsOverlap", supportsInterpolation: false)
+// An enum would probably be better?
+@MLNStyleProperty<String>("textAnchor", supportsInterpolation: false)
+@MLNStyleProperty<CGVector>("textOffset", supportsInterpolation: true)
+@MLNStyleProperty<Double>("maximumTextWidth", supportsInterpolation: true)
+
+@MLNStyleProperty<UIColor>("textHaloColor", supportsInterpolation: true)
+@MLNStyleProperty<Double>("textHaloWidth", supportsInterpolation: true)
+@MLNStyleProperty<Double>("textHaloBlur", supportsInterpolation: true)
 
 public struct SymbolStyleLayer: SourceBoundVectorStyleLayerDefinition {
     public let identifier: String
+    public let sourceLayerIdentifier: String?
     public var insertionPosition: LayerInsertionPosition = .aboveOthers
     public var isVisible: Bool = true
     public var maximumZoomLevel: Float? = nil
@@ -22,12 +32,15 @@ public struct SymbolStyleLayer: SourceBoundVectorStyleLayerDefinition {
 
     public init(identifier: String, source: Source) {
         self.identifier = identifier
+        self.sourceLayerIdentifier = nil
         self.source = .source(source)
     }
 
-    public init(identifier: String, source: MLNSource) {
+    public init(identifier: String, source: MLNSource, sourceLayerIdentifier: String? = nil) {
         self.identifier = identifier
+        self.sourceLayerIdentifier = sourceLayerIdentifier
         self.source = .mglSource(source)
+        
     }
 
     public func makeStyleLayer(style: MLNStyle) -> StyleLayer {
@@ -40,10 +53,9 @@ public struct SymbolStyleLayer: SourceBoundVectorStyleLayerDefinition {
         return SymbolStyleLayerInternal(definition: self, mglSource: styleSource)
     }
 
-    // TODO: Other properties and their modifiers
-    fileprivate var iconImageName: NSExpression?
+    public var iconImageName: NSExpression?
 
-    private var iconImages = [UIImage]()
+    public var iconImages = [UIImage]()
 
     // MARK: - Modifiers
 
@@ -52,6 +64,12 @@ public struct SymbolStyleLayer: SourceBoundVectorStyleLayerDefinition {
             it.iconImageName = NSExpression(forConstantValue: image.sha256())
             it.iconImages = [image]
         }
+    }
+    
+    public func iconImage(featurePropertyNamed keyPath: String) -> Self {
+        var copy = self
+        copy.iconImageName = NSExpression(forKeyPath: keyPath)
+        return copy
     }
 
     // FIXME: This appears to be broken upstream; waiting for a new release
@@ -66,6 +84,29 @@ public struct SymbolStyleLayer: SourceBoundVectorStyleLayerDefinition {
 //            it.iconImages = mappings.values + [defaultImage]
 //        }
 //    }
+    
+    /// Add an icon image that can be dynamic and use UIImages in your app, based on a feature property of the source. For example, your feature could have a property called "icon-name". This name is then resolved against the key in the mappings dictionary and used to find a UIImage to display on the map for that feature.
+    /// - Parameters:
+    ///   - keyPath: The keypath to the feature property containing the icon to use, for example "icon-name".
+    ///   - mappings: A lookup dictionary containing the keys found in "keyPath" and a UIImage for each keyPath. The key of the mappings dictionary needs to match the value type stored at keyPath, for example `String`.
+    ///   - defaultImage: A UIImage that MapLibre should fall back to if the key in your feature is not found in the mappings table
+    public func iconImage(featurePropertyNamed keyPath: String, mappings: [AnyHashable: UIImage], default defaultImage: UIImage) -> Self {
+        return modified(self) { it in
+            let attributeExpression = NSExpression(forKeyPath: keyPath)
+            let mappingExpressions = mappings.mapValues { image in
+                NSExpression(forConstantValue: image.sha256())
+            }
+            let mappingDictionary = NSDictionary(dictionary: mappingExpressions)
+            let defaultExpression = NSExpression(forConstantValue: defaultImage.sha256())
+            
+            it.iconImageName = NSExpression(
+                forMLNMatchingKey: attributeExpression,
+                in: mappingDictionary as! [NSExpression: NSExpression],
+                default: defaultExpression
+            )
+            it.iconImages = mappings.values + [defaultImage]
+        }
+    }
 }
 
 private struct SymbolStyleLayerInternal: StyleLayer {
@@ -100,16 +141,24 @@ private struct SymbolStyleLayerInternal: StyleLayer {
 
     public func makeMLNStyleLayer() -> MLNStyleLayer {
         let result = MLNSymbolStyleLayer(identifier: identifier, source: mglSource)
-
+        result.sourceLayerIdentifier = definition.sourceLayerIdentifier
+        
         result.iconImageName = definition.iconImageName
         result.iconRotation = definition.iconRotation
+        result.iconAllowsOverlap = definition.iconAllowsOverlap
         result.iconColor = definition.iconColor
+        
         result.text = definition.text
         result.textColor = definition.textColor
         result.textFontSize = definition.textFontSize
-
-        result.iconAllowsOverlap = definition.iconAllowsOverlap
-
+        result.maximumTextWidth = definition.maximumTextWidth
+        result.textAnchor = definition.textAnchor
+        result.textOffset = definition.textOffset
+        
+        result.textHaloColor = definition.textHaloColor
+        result.textHaloWidth = definition.textHaloWidth
+        result.textHaloBlur = definition.textHaloBlur
+        
         result.predicate = definition.predicate
 
         return result


### PR DESCRIPTION
Do not merge! This currently points at a branch that itself is being reviewed for integration into upstream - if you merge this, this becomes part of that other PR, and the other PR is then unlikely to be merged. Instead, let hudhud depend on this branch for now.

This PR includes needed changes to MapLibre to support showing an icon based on a feature property in a map source. Changes:
- exposing needed properties of MLN things
- new function for adding UIImages to the sprite sheet
- exposure of zoom level related modifiers

Here's an example of what is now possible in symbol layer:

![Simulator Screenshot - iPhone 15 Pro - 2024-07-11 at 12 35 29](https://github.com/HudHud-Maps/maplibre-swiftui-dsl-playground/assets/645674/3a482c89-c029-43d8-bcf2-0902199fae98)
